### PR TITLE
API can provide products sorted in categories

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,3 @@
 class Product < ApplicationRecord
-    validates_presence_of :name, :description, :price
+    validates_presence_of :name, :description, :price, :category
 end

--- a/db/migrate/20200306152921_add_category_to_products.rb
+++ b/db/migrate/20200306152921_add_category_to_products.rb
@@ -1,0 +1,5 @@
+class AddCategoryToProducts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :products, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_04_122406) do
+ActiveRecord::Schema.define(version: 2020_03_06_152921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_03_04_122406) do
     t.money "price", scale: 2
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "category"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :product do
+    category { "Burgers" }
     name { "Cheeseburger" }
     description { "Bun, meat and cheese" }
     price { 100 }

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe Product, type: :model do
   end
 
   describe 'Database table' do
+    it { is_expected.to have_db_column :category }
     it { is_expected.to have_db_column :name }
     it { is_expected.to have_db_column :description }
     it { is_expected.to have_db_column :price }
   end
 
   describe 'Validations' do
+    it { is_expected.to validate_presence_of :category}
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :price }  
@@ -29,6 +31,20 @@ RSpec.describe Product, type: :model do
 
     it "expects to contain the description" do      
       expect(@product1.description).to eq("best pasta you can eat")
+    end
+  end
+
+  describe "Check if product has a Category" do
+    before do
+    @product2 = Product.new(category:"Pizza", name:"Janko Special" , description:"best pizza from the east", price: 400,)
+    end  
+
+    it "expects to contain the dish name" do
+    expect(@product2.category).to eq("Pizza")
+    end
+
+    it "expects to contain the description" do      
+      expect(@product2.description).to eq("best pizza from the east")
     end
   end
 end


### PR DESCRIPTION
PT:  https://www.pivotaltracker.com/story/show/171561434

```
As a restaurant API
In order to give the client better sorted products
I would like to be able to send off the products with their category listed
```

We learned to do migrations and add new columns to an already existing table of content.